### PR TITLE
Add test coverage for Ruby 3.0, 3.1 and 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
         - '2.5'
         - '2.6'
         - '2.7'
+        - '3.2'
+        - '3.1'
+        - '3.0'
         - ruby-head
         - jruby-head
         - truffleruby-head


### PR DESCRIPTION
With this PR, test coverage is added for Ruby 3.0, 3.1, and 3.2.